### PR TITLE
Typofix: 11-20 & 11-28

### DIFF
--- a/source/part3/11_1_loops.md
+++ b/source/part3/11_1_loops.md
@@ -318,7 +318,7 @@ fstring="Free Software Foundation"  # 查看哪些文件来自于 FSF。
 
 for file in $( find $directory -type f -name '*' | sort )
 do
-  strings -f $file | grep "$fstring" | sed -e "s%$driectory%%"
+  strings -f $file | grep "$fstring" | sed -e "s%$directory%%"
   #  在 "sed" 表达式中，你需要替换掉 "/" 分隔符，
   #+ 因为 "/" 是一个会被过滤的字符。
   #  如果不做替换，将会产生一个错误。（你可以尝试一下。）

--- a/source/part3/11_4_testing_and_branching.md
+++ b/source/part3/11_4_testing_and_branching.md
@@ -229,7 +229,7 @@ echo $?             # 91
 match_string $a $b  # 匹配不到
 echo $?             # 90
 
-match_string $a $d  # 匹配成功
+match_string $b $d  # 匹配成功
 echo $?             # 0
 
 


### PR DESCRIPTION
Typofix
---
1. 样例11-10中修正“目录”拼写“driectory”为"directory"。
2. 样例11-28中match_string()函数作用为匹配字符串$1、$2。
   - 原文b与d值相等，返回0状态码。
   - 译文a与d值不等，应返回90状态码。
